### PR TITLE
Bugfixes and Localization

### DIFF
--- a/AutoDarkModeApp/Pages/PageSwitchModes.xaml
+++ b/AutoDarkModeApp/Pages/PageSwitchModes.xaml
@@ -8,7 +8,7 @@
       xmlns:p="clr-namespace:AutoDarkModeApp.Properties"
       mc:Ignorable="d" 
       
-      d:DesignHeight="450" d:DesignWidth="800"
+      d:DesignHeight="800" d:DesignWidth="800"
       Title="PageSwitchModes"
       Height="Auto" Width="Auto">
 
@@ -111,6 +111,78 @@
                 Margin="0,0,0,0" 
                 Click="CheckBoxBatteryDarkMode_Click"
                 />
+
+            <TextBlock
+                Name="TextBlockHotkeys"
+                Margin="0,40,0,10"
+                Text="{x:Static p:Resources.SwitchModesTextBlockHeaderHotkeys}"
+                FontFamily="Segoe UI"
+                FontSize="19"
+                />
+
+            <ui:ToggleSwitch
+                Name="ToggleHotkeys"
+                OffContent="{x:Static p:Resources.ToggleSwitchOff}"
+                OnContent="{x:Static p:Resources.ToggleSwitchOn}"
+                Grid.Row="0"
+                Margin="0,10,0,0"
+                Header="{x:Static p:Resources.SwitchModesToggleHeaderHotkey}"
+                Toggled="ToggleHotkeys_Toggled"
+            />
+
+            <TextBlock
+                Name="TextBlockHotkeyEditHint"
+                Foreground="#999999"
+                Text="{x:Static p:Resources.SwitchModesHotkeyEditHint}"
+                FontSize="14"
+                />
+
+            <Grid Name="GridHotkeys">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+
+                <ui:SimpleStackPanel Margin="0,10,0,0" Grid.Row="0">
+                    <TextBlock Text="{x:Static p:Resources.SwitchModesTextBlockHeaderForceLightHotkey}"
+                               FontSize="14"
+                    />
+                    <TextBox HorizontalAlignment="Left" 
+                             ui:TextBoxHelper.IsDeleteButtonVisible="false"
+                             Width="240" Margin="0,5,0,0" 
+                             Grid.Column="1" 
+                             Name="HotkeyTextboxForceLight" 
+                             PreviewKeyDown="HotkeyTextboxForceLight_PreviewKeyDown"/>
+                </ui:SimpleStackPanel>
+                
+                <ui:SimpleStackPanel Margin="0,10,0,0" Grid.Row="1">
+                    <TextBlock
+                    Text="{x:Static p:Resources.SwitchModesTextBlockHeaderForceDarkHotkey}"
+                    FontSize="14"
+                    />
+                    <TextBox HorizontalAlignment="Left" 
+                             ui:TextBoxHelper.IsDeleteButtonVisible="false"
+                             Width="240" 
+                             Margin="0,5,0,0" 
+                             Grid.Column="1" 
+                             Name="HotkeyTextboxForceDark" 
+                             PreviewKeyDown="HotkeyTextboxForceDark_PreviewKeyDown"/>
+                </ui:SimpleStackPanel>
+
+                <ui:SimpleStackPanel Margin="0,10,0,0" Grid.Row="2">
+                    <TextBlock Text="{x:Static p:Resources.SwitchModesTextBlockHeaderNoForceHotkey}"
+                               FontSize="14"
+                    />
+                    <TextBox HorizontalAlignment="Left" 
+                             ui:TextBoxHelper.IsDeleteButtonVisible="false"
+                             Width="240"
+                             Margin="0,5,0,0" 
+                             Grid.Column="1" 
+                             Name="HotkeyTextboxNoForce" 
+                             PreviewKeyDown="HotkeyTextboxNoForce_PreviewKeyDown"/>
+                </ui:SimpleStackPanel>
+            </Grid>
         </ui:SimpleStackPanel>
     </Grid>
 </Page>

--- a/AutoDarkModeApp/Pages/PageSwitchModes.xaml.cs
+++ b/AutoDarkModeApp/Pages/PageSwitchModes.xaml.cs
@@ -48,6 +48,8 @@ namespace AutoDarkModeApp.Pages
             HotkeyTextboxForceLight.Text = builder.Config.Hotkeys.ForceLightHotkey ?? "";
             HotkeyTextboxNoForce.Text = builder.Config.Hotkeys.NoForceHotkey ?? "";
             ToggleHotkeys.IsOn = builder.Config.Hotkeys.Enabled;
+            TextBlockHotkeyEditHint.Visibility = ToggleHotkeys.IsOn ? Visibility.Visible : Visibility.Hidden;
+
             init = false;
         }
 
@@ -134,6 +136,7 @@ namespace AutoDarkModeApp.Pages
         private void ComboBoxGPUSamples_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             builder.Config.GPUMonitoring.Samples = ComboBoxGPUSamples.SelectedIndex + 1;
+            if (init) return;
             try
             {
                 builder.Save();
@@ -149,7 +152,6 @@ namespace AutoDarkModeApp.Pages
             TextBlockHotkeyEditHint.Visibility = ToggleHotkeys.IsOn ? Visibility.Visible : Visibility.Hidden;
             if (ToggleHotkeys.IsOn) GridHotkeys.IsEnabled = false;
             else GridHotkeys.IsEnabled = true;
-
             if (init) return;
             builder.Config.Hotkeys.Enabled = ToggleHotkeys.IsOn;
             try
@@ -169,6 +171,7 @@ namespace AutoDarkModeApp.Pages
             {
                 tb.Text = hotkeyString;
             }
+            if (hotkeyString == builder.Config.Hotkeys.NoForceHotkey) return;
             builder.Config.Hotkeys.NoForceHotkey = hotkeyString;
             try
             {
@@ -187,6 +190,7 @@ namespace AutoDarkModeApp.Pages
             {
                 tb.Text = hotkeyString;
             }
+            if (hotkeyString == builder.Config.Hotkeys.ForceDarkHotkey) return;
             builder.Config.Hotkeys.ForceDarkHotkey = hotkeyString;
             try
             {
@@ -205,6 +209,7 @@ namespace AutoDarkModeApp.Pages
             {
                 tb.Text = hotkeyString;
             }
+            if (hotkeyString == builder.Config.Hotkeys.ForceLightHotkey) return;
             builder.Config.Hotkeys.ForceLightHotkey = hotkeyString;
             try
             {
@@ -224,7 +229,7 @@ namespace AutoDarkModeApp.Pages
 
             if (keyString.Contains("Alt") || keyString.Contains("Shift") || keyString.Contains("Win") || keyString.Contains("Ctrl"))
             {
-                return "";
+                return null;
             }
 
             ModifierKeys modifiers = Keyboard.Modifiers;
@@ -233,7 +238,7 @@ namespace AutoDarkModeApp.Pages
             string isWin = (modifiers & ModifierKeys.Windows) == ModifierKeys.Windows ? "LWin + " : "";
             string isAlt = (modifiers & ModifierKeys.Alt) == ModifierKeys.Alt ? "Alt + " : "";
             string modifiersString = $"{isCtrl}{isShift}{isAlt}{isWin}";
-            return modifiersString.Length > 0 ? $"{modifiersString}{key}" : "";
+            return modifiersString.Length > 0 ? $"{modifiersString}{key}" : null;
         }
     }
 }

--- a/AutoDarkModeApp/Pages/PageTime.xaml
+++ b/AutoDarkModeApp/Pages/PageTime.xaml
@@ -200,8 +200,8 @@
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
 
-                <TextBlock Grid.Column="0" Foreground="#696969" FontSize="12" Text="Next update at"/>
-                <TextBlock Margin="4,0,0,0" Grid.Column="1" Foreground="#696969" FontSize="12" Name="LocationNextUpdateDate"/>
+                <TextBlock Grid.Column="0" Foreground="#999999" FontSize="12" Text="Next update at"/>
+                <TextBlock Margin="4,0,0,0" Grid.Column="1" Foreground="#999999" FontSize="12" Name="LocationNextUpdateDate"/>
             </Grid>
         </Grid>
 

--- a/AutoDarkModeApp/Properties/Resources.Designer.cs
+++ b/AutoDarkModeApp/Properties/Resources.Designer.cs
@@ -1203,6 +1203,15 @@ namespace AutoDarkModeApp.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You can only edit hotkeys while they are disabled..
+        /// </summary>
+        public static string SwitchModesHotkeyEditHint {
+            get {
+                return ResourceManager.GetString("SwitchModesHotkeyEditHint", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to GPU usage detection speed.
         /// </summary>
         public static string SwitchModesTextBlockGPUUsageDetectionSpeed {
@@ -1230,11 +1239,56 @@ namespace AutoDarkModeApp.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Force Dark Mode Hotkey.
+        /// </summary>
+        public static string SwitchModesTextBlockHeaderForceDarkHotkey {
+            get {
+                return ResourceManager.GetString("SwitchModesTextBlockHeaderForceDarkHotkey", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Force Light Mode Hotkey.
+        /// </summary>
+        public static string SwitchModesTextBlockHeaderForceLightHotkey {
+            get {
+                return ResourceManager.GetString("SwitchModesTextBlockHeaderForceLightHotkey", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Hotkeys.
+        /// </summary>
+        public static string SwitchModesTextBlockHeaderHotkeys {
+            get {
+                return ResourceManager.GetString("SwitchModesTextBlockHeaderHotkeys", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Stop Forcing Theme Hotkey.
+        /// </summary>
+        public static string SwitchModesTextBlockHeaderNoForceHotkey {
+            get {
+                return ResourceManager.GetString("SwitchModesTextBlockHeaderNoForceHotkey", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Minimum GPU usage to delay switching.
         /// </summary>
         public static string SwitchModesTextBlockMinimumUsage {
             get {
                 return ResourceManager.GetString("SwitchModesTextBlockMinimumUsage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enable system-wide hotkeys.
+        /// </summary>
+        public static string SwitchModesToggleHeaderHotkey {
+            get {
+                return ResourceManager.GetString("SwitchModesToggleHeaderHotkey", resourceCulture);
             }
         }
         

--- a/AutoDarkModeApp/Properties/Resources.resx
+++ b/AutoDarkModeApp/Properties/Resources.resx
@@ -756,4 +756,22 @@ Sidenote: NEVER run Auto Dark Mode as administrator manually!</value>
   <data name="AppSystemComboBoxItemAccentOnly" xml:space="preserve">
     <value>Accent only</value>
   </data>
+  <data name="SwitchModesHotkeyEditHint" xml:space="preserve">
+    <value>You can only edit hotkeys while they are disabled.</value>
+  </data>
+  <data name="SwitchModesTextBlockHeaderForceDarkHotkey" xml:space="preserve">
+    <value>Force Dark Mode Hotkey</value>
+  </data>
+  <data name="SwitchModesTextBlockHeaderForceLightHotkey" xml:space="preserve">
+    <value>Force Light Mode Hotkey</value>
+  </data>
+  <data name="SwitchModesTextBlockHeaderHotkeys" xml:space="preserve">
+    <value>Hotkeys</value>
+  </data>
+  <data name="SwitchModesTextBlockHeaderNoForceHotkey" xml:space="preserve">
+    <value>Stop Forcing Theme Hotkey</value>
+  </data>
+  <data name="SwitchModesToggleHeaderHotkey" xml:space="preserve">
+    <value>Enable system-wide hotkeys</value>
+  </data>
 </root>

--- a/AutoDarkModeSvc/AutoDarkModeSvc.csproj
+++ b/AutoDarkModeSvc/AutoDarkModeSvc.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
     <UseWindowsForms>true</UseWindowsForms>
-    <Version>10.0.2.22</Version>
+    <Version>10.1.0.0</Version>
     <AssemblyName>AutoDarkModeSvc</AssemblyName>
     <ApplicationIcon>..\adm_tray_new.ico</ApplicationIcon>
     <StartupObject>AutoDarkModeSvc.Program</StartupObject>


### PR DESCRIPTION
**Fixed bugs: Application was crashing when leaving "NumberBoxGPUThreshold" or "NumberBoxColorDelay" control empty and clicking on other control.**

**Translated missing strings to Polish**

**Added localization support and English+Polish translation for non-localized controls:**

about page:
- version label
- find us label
- copy button

settings page:
- language section header
- restart button
- autostart section header
- autostart section description
- autostart table mode
- autostart table path
- warning when autostart disabled in windows

wallpaper page:
- color header


